### PR TITLE
Update setup.md

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -22,7 +22,7 @@ You will want to get the Home edition (Installer edition).
 **macOS**
 
 Although macOS comes with SSH pre-installed, 
-you will likely want to install [XQuartz](www.xquartz.org) to enable graphical support.
+you will likely want to install [XQuartz](https://www.xquartz.org) to enable graphical support.
 Note that you must restart your computer to complete the installation.
 
 **Linux**


### PR DESCRIPTION
For some reason, the existing link to Quartz is changed in the gh-pages so that it goes to a 404 page.

It becomes http://rits.github-pages.ucl.ac.uk/hpc-shell/setup/www.xquartz.org

Hopefully this will fix it